### PR TITLE
Icon Loading Performance Adjustment

### DIFF
--- a/src/Icons/IconManager.php
+++ b/src/Icons/IconManager.php
@@ -49,6 +49,27 @@ class IconManager
 
     public function getIcon(?string $id, bool $checkScope = false): ?Icon
     {
-        return $this->getIcons(checkScope: $checkScope)->first(fn (Icon $icon) => $icon->id === $id);
+        if ($id === null) {
+            return null;
+        }
+
+        if ($checkScope) {
+            return $this->getIcons(checkScope: $checkScope)->first(fn (Icon $icon) => $icon->id === $id);
+        }
+
+        /** @var IconSet[] $sets */
+        $sets = $this->getSets();
+
+        foreach ($sets as $set) {
+            if (str($id)->startsWith($set->getPrefix())) {
+                return new Icon(
+                    $id,
+                    str($id)->headline()->lower()->ucfirst(),
+                    $set
+                );
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
The plugin was taking an average of 30 seconds to process the loading of individual icons.

It was adjusted so that instead of using getIcon to load all icons, it now returns the Icon object based on the icon prefix. When $checkScope is true, it continues with the loading logic and checks the rules, referencing $checkScope.

This changed from taking 8 seconds to load to less than 200ms.