### PR TITLE
fix: remove Storage::makeDirectory from boot to prevent rate limits

### DIFF
--- a/src/IconPickerServiceProvider.php
+++ b/src/IconPickerServiceProvider.php
@@ -11,7 +11,6 @@ use Guava\IconPicker\Testing\TestsIconPicker;
 use Livewire\Features\SupportTesting\Testable;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
-use Storage;
 
 class IconPickerServiceProvider extends PackageServiceProvider
 {
@@ -40,8 +39,6 @@ class IconPickerServiceProvider extends PackageServiceProvider
     public function packageRegistered(): void
     {
         $this->callAfterResolving(IconFactory::class, function (IconFactory $factory) {
-            Storage::disk('public')->makeDirectory('icon-picker-icons');
-
             $factory->add('icon-picker-icons', [
                 'path' => 'icon-picker-icons',
                 'disk' => 'public',


### PR DESCRIPTION
## Summary

- Removes `Storage::disk('public')->makeDirectory('icon-picker-icons')` from `packageRegistered()`
- Removes the now-unused `Storage` import

## Problem

`IconPickerServiceProvider::packageRegistered()` calls `Storage::disk('public')->makeDirectory('icon-picker-icons')` inside a `callAfterResolving` callback. This runs on **every request**, making an API call to the configured public disk each time.

For applications using cloud storage backends (S3, Cloudflare R2, etc.) as their `public` disk, this causes:
- An unnecessary PUT request on every single HTTP request
- **429 Too Many Requests** errors under concurrent load due to rate limiting

## Fix

The `makeDirectory` call is removed entirely. It is not needed at boot time because:
1. Filament's `FileUpload` component (used in `UploadCustomIcon`) already handles directory creation when a custom icon is uploaded
2. The `icon-picker-icons` directory only needs to exist when custom icons are actually stored — not on every request
3. The `IconFactory::add()` registration does not require the directory to exist

Fixes #62